### PR TITLE
fix: Fix scrcpy-server path being null if not set in config (Windows)

### DIFF
--- a/guiscrcpy/launcher.py
+++ b/guiscrcpy/launcher.py
@@ -1197,9 +1197,10 @@ def set_scrcpy_server_path(config):
             config['scrcpy-server'] = server_path
             os.environ['SCRCPY_SERVER_PATH'] = server_path
     elif (
-        (scrcpy_server_path_env is None) and
-        (isinstance(config.get('scrcpy-server'), str) and
-         not os.path.exists(config.get('scrcpy-server')))
+        (scrcpy_server_path_env is None) and (
+            (isinstance(config.get('scrcpy-server'), str) and
+             not os.path.exists(config.get('scrcpy-server'))) or
+            config.get('scrcpy-server') is None)
     ) and (
         platform.System().system() == 'Windows'
     ):


### PR DESCRIPTION
Fixes #172
Scrcpy server path was set as null in the config and guiscrcpy did not try to ask the user
for the path to scrcpy-server despite being null. This was because of a missing condition which
checks if scrcpy-server is null. Now it shows a file dialog box if scrcpy-server is Null