### PR TITLE
Fix Windows shortcut

### DIFF
--- a/guiscrcpy/launcher.py
+++ b/guiscrcpy/launcher.py
@@ -312,9 +312,9 @@ class InterfaceGuiscrcpy(QMainWindow, Ui_MainWindow):
                 print()
                 _, identifier = self.current_device_identifier()
                 executable = get_self()
-                from .lib.utils import shellify as sx
+                from .lib.utils import shellify as sx, open_process
 
-                subprocess.Popen(
+                open_process(
                     sx("{} mapper".format(executable)),
                     stdout=sys.stdout,
                     stdin=sys.stdin,

--- a/guiscrcpy/lib/bridge/adb.py
+++ b/guiscrcpy/lib/bridge/adb.py
@@ -1,10 +1,10 @@
 import logging
 import sys
-from subprocess import Popen, PIPE, TimeoutExpired, call
+from subprocess import PIPE, TimeoutExpired, call
 
 from .base import Bridge
 from ..check import _get_dimension_raw_noexcept, get
-from ..utils import decode_process, _
+from ..utils import decode_process, open_process, _
 
 
 class AndroidDebugBridge(Bridge):
@@ -21,13 +21,13 @@ class AndroidDebugBridge(Bridge):
     def shell_input(self, command, device_id=None):
         path = self.path
         if device_id:
-            Popen(
+            open_process(
                 _("{} -s {} shell input {}".format(path, device_id, command)),
                 stdout=PIPE,
                 stderr=PIPE,
             )
         else:
-            Popen(
+            open_process(
                 _("{} shell input {}".format(path, command)),
                 stdout=PIPE,
                 stderr=PIPE,
@@ -77,26 +77,26 @@ class AndroidDebugBridge(Bridge):
 
     def shell(self, command, device_id=None):
         if device_id:
-            po = Popen(
+            po = open_process(
                 _("{} -s {} shell {}".format(self.path, device_id, command)),
                 stdout=PIPE,
                 stderr=PIPE,
             )
         else:
-            po = Popen(
+            po = open_process(
                 _("{} shell {}".format(self.path, command)), stdout=PIPE, stderr=PIPE
             )
         return po
 
     def command(self, command, device_id=None):
         if device_id:
-            adb_shell_output = Popen(
+            adb_shell_output = open_process(
                 _("{} -s {} {}".format(self.path, device_id, command)),
                 stdout=PIPE,
                 stderr=PIPE,
             )
         else:
-            adb_shell_output = Popen(
+            adb_shell_output = open_process(
                 _("{} {}".format(self.path, command)), stdout=PIPE, stderr=PIPE
             )
         return adb_shell_output
@@ -114,7 +114,7 @@ class AndroidDebugBridge(Bridge):
         return exit_code
 
     def devices(self):
-        proc = Popen(_(self.path + " devices"), stdout=PIPE)
+        proc = open_process(_(self.path + " devices"), stdout=PIPE)
         output = [[y.strip() for y in x.split("\t")] for x in decode_process(proc)[1:]][
             :-1
         ]
@@ -123,7 +123,7 @@ class AndroidDebugBridge(Bridge):
         return output
 
     def devices_detailed(self):
-        proc = Popen(_(self.path + " devices -l"), stdout=PIPE)
+        proc = open_process(_(self.path + " devices -l"), stdout=PIPE)
         output = [[y.strip() for y in x.split()] for x in decode_process(proc)[1:]][:-1]
         devices_found = []
         for device in output:

--- a/guiscrcpy/lib/bridge/audio/sndcpy.py
+++ b/guiscrcpy/lib/bridge/audio/sndcpy.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 
 from .base import AudioBridge
-from ...utils import shellify as _, show_message_box
+from ...utils import shellify as _, show_message_box, open_process
 
 
 class SndcpyBridge(AudioBridge):
@@ -14,7 +14,7 @@ class SndcpyBridge(AudioBridge):
             command = "{sndcpy}"
         else:
             command = "{sndcpy} {device_id}"
-        _proc = subprocess.Popen(
+        _proc = open_process(
             _(command.format(sndcpy=self.get_path(), device_id=device_id)),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/guiscrcpy/lib/bridge/audio/usbaudio.py
+++ b/guiscrcpy/lib/bridge/audio/usbaudio.py
@@ -3,7 +3,7 @@ import subprocess
 
 
 from .base import AudioBridge
-from ...utils import shellify as _
+from ...utils import shellify as _, open_process
 
 
 class USBAudioBridge(AudioBridge):
@@ -14,7 +14,7 @@ class USBAudioBridge(AudioBridge):
             command = "{usbaudio}"
         else:
             command = "{usbaudio} --serial {device_id}"
-        subprocess.Popen(
+        open_process(
             _(command.format(usbaudio=self.get_path(), device_id=device_id)),
             stdout=sys.stdout,
             stderr=sys.stderr,

--- a/guiscrcpy/lib/bridge/scrcpy.py
+++ b/guiscrcpy/lib/bridge/scrcpy.py
@@ -1,8 +1,8 @@
 import os
-from subprocess import Popen, PIPE
+from subprocess import PIPE
 
 from .base import Bridge
-from ...lib.utils import shellify as _
+from ...lib.utils import shellify as _, open_process
 
 
 class ScrcpyBridge(Bridge):
@@ -16,7 +16,7 @@ class ScrcpyBridge(Bridge):
                 os.environ["LD_LIBRARY_PATH"] = os.getenv("SCRCPY_LDD")
 
     def start(self, args, stdout=PIPE, stderr=PIPE):
-        proc = Popen(
+        proc = open_process(
             _("{} {}".format(self.path, args)),
             stdout=stdout,
             stderr=stderr,

--- a/guiscrcpy/lib/check.py
+++ b/guiscrcpy/lib/check.py
@@ -37,5 +37,7 @@ def _get_dimension_raw_noexcept(path, device_id=None):
             stderr=PIPE,
         )
     else:
-        shell_adb = open_process(_("{} shell wm size".format(path)), stdout=PIPE, stderr=PIPE)
+        shell_adb = open_process(
+            _("{} shell wm size".format(path)), stdout=PIPE, stderr=PIPE
+        )
     return shell_adb

--- a/guiscrcpy/lib/check.py
+++ b/guiscrcpy/lib/check.py
@@ -17,9 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from subprocess import Popen, PIPE
+from subprocess import PIPE
 
-from ..lib.utils import shellify as _
+from ..lib.utils import shellify as _, open_process
 
 
 def get(ls, idx, default=""):
@@ -31,11 +31,11 @@ def get(ls, idx, default=""):
 
 def _get_dimension_raw_noexcept(path, device_id=None):
     if device_id:
-        shell_adb = Popen(
+        shell_adb = open_process(
             _("{} -s {} shell wm size".format(path, device_id)),
             stdout=PIPE,
             stderr=PIPE,
         )
     else:
-        shell_adb = Popen(_("{} shell wm size".format(path)), stdout=PIPE, stderr=PIPE)
+        shell_adb = open_process(_("{} shell wm size".format(path)), stdout=PIPE, stderr=PIPE)
     return shell_adb

--- a/guiscrcpy/lib/utils.py
+++ b/guiscrcpy/lib/utils.py
@@ -164,12 +164,13 @@ def show_message_box(text, info_text="", buttons=QMessageBox.Ok):
     message_box.setStandardButtons(buttons)
     return message_box
 
-def open_process(command, stdin=None, stdout=None, stderr=None):
+def open_process(command, stdin=None, stdout=None, stderr=None, cwd=None):
     # warning: CREATE_NO_WINDOW is added in Python 3.7
     return Popen(
         command,
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,
+        cwd=cwd,
         creationflags=CREATE_NO_WINDOW
     )

--- a/guiscrcpy/lib/utils.py
+++ b/guiscrcpy/lib/utils.py
@@ -28,6 +28,7 @@ from colorama import Fore
 from qtpy import QtCore
 from qtpy.QtWidgets import QMessageBox
 from ..platform.platform import System
+from subprocess import Popen
 
 environment = System()
 
@@ -162,3 +163,11 @@ def show_message_box(text, info_text="", buttons=QMessageBox.Ok):
     message_box.setInformativeText(info_text)
     message_box.setStandardButtons(buttons)
     return message_box
+
+def open_process(command, stdin=None, stdout=None, stderr=None):
+    return Popen(
+        command,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+    )

--- a/guiscrcpy/lib/utils.py
+++ b/guiscrcpy/lib/utils.py
@@ -28,7 +28,7 @@ from colorama import Fore
 from qtpy import QtCore
 from qtpy.QtWidgets import QMessageBox
 from ..platform.platform import System
-from subprocess import Popen
+from subprocess import Popen, CREATE_NO_WINDOW
 
 environment = System()
 
@@ -165,9 +165,11 @@ def show_message_box(text, info_text="", buttons=QMessageBox.Ok):
     return message_box
 
 def open_process(command, stdin=None, stdout=None, stderr=None):
+    # warning: CREATE_NO_WINDOW is added in Python 3.7
     return Popen(
         command,
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,
+        creationflags=CREATE_NO_WINDOW
     )

--- a/guiscrcpy/lib/utils.py
+++ b/guiscrcpy/lib/utils.py
@@ -22,13 +22,13 @@ import os
 import shlex
 import shutil
 import sys
+import subprocess
 
 from qtpy.QtGui import QPixmap
 from colorama import Fore
 from qtpy import QtCore
 from qtpy.QtWidgets import QMessageBox
 from ..platform.platform import System
-from subprocess import Popen, CREATE_NO_WINDOW
 
 environment = System()
 
@@ -171,10 +171,10 @@ def open_process(*args, **kwargs):
         and sys.version_info.major >= 3
         and sys.version_info.minor >= 7
     ):
-        return Popen(
+        return subprocess.Popen(
             *args,
             **kwargs,
-            creationflags=CREATE_NO_WINDOW,
+            creationflags=subprocess.CREATE_NO_WINDOW,
         )
     else:
-        return Popen(*args, **kwargs)
+        return subprocess.Popen(*args, **kwargs)

--- a/guiscrcpy/lib/utils.py
+++ b/guiscrcpy/lib/utils.py
@@ -164,6 +164,7 @@ def show_message_box(text, info_text="", buttons=QMessageBox.Ok):
     message_box.setStandardButtons(buttons)
     return message_box
 
+
 def open_process(command, stdin=None, stdout=None, stderr=None, cwd=None):
     # warning: CREATE_NO_WINDOW is added in Python 3.7
     return Popen(
@@ -172,5 +173,5 @@ def open_process(command, stdin=None, stdout=None, stderr=None, cwd=None):
         stdout=stdout,
         stderr=stderr,
         cwd=cwd,
-        creationflags=CREATE_NO_WINDOW
+        creationflags=CREATE_NO_WINDOW,
     )

--- a/guiscrcpy/lib/utils.py
+++ b/guiscrcpy/lib/utils.py
@@ -165,13 +165,16 @@ def show_message_box(text, info_text="", buttons=QMessageBox.Ok):
     return message_box
 
 
-def open_process(command, stdin=None, stdout=None, stderr=None, cwd=None):
-    # warning: CREATE_NO_WINDOW is added in Python 3.7
-    return Popen(
-        command,
-        stdin=stdin,
-        stdout=stdout,
-        stderr=stderr,
-        cwd=cwd,
-        creationflags=CREATE_NO_WINDOW,
-    )
+def open_process(*args, **kwargs):
+    if (
+        environment.system() == "Windows"
+        and sys.version_info.major >= 3
+        and sys.version_info.minor >= 7
+    ):
+        return Popen(
+            *args,
+            **kwargs,
+            creationflags=CREATE_NO_WINDOW,
+        )
+    else:
+        return Popen(*args, **kwargs)

--- a/guiscrcpy/platform/windows_tools/tools.py
+++ b/guiscrcpy/platform/windows_tools/tools.py
@@ -92,7 +92,7 @@ def make_shortcut():
         dest = os.path.join(folder, "guiscrcpy.lnk")
 
         wscript = _WSHELL.CreateShortCut(dest)
-        wscript.Targetpath = "guiscrcpy.exe"
+        wscript.Targetpath = "guiscrcpy-noconsole.exe"
         wscript.WorkingDirectory = userfolders.home
         wscript.WindowStyle = 0
         wscript.Description = "An Open Source Android Screen Mirroring System"

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ data_files = [
         ('share/applications', ['guiscrcpy.desktop']),
         ('share/icons/hicolor/scalable/apps', ['appimage/guiscrcpy.png']),
     ]
+guiscrcpy_main = 'guiscrcpy.cli:cli'
 
 setup(
     name="guiscrcpy",
@@ -67,7 +68,10 @@ setup(
     },
     install_requires=requirements,
     scripts=["scripts/guiscrcpy"],
-    entry_points={'console_scripts': ['guiscrcpy = guiscrcpy.cli:cli']},  # noqa: E501
+    entry_points={
+        'console_scripts': ['guiscrcpy = ' + guiscrcpy_main],
+        'gui_scripts': ['guiscrcpy-noconsole = ' + guiscrcpy_main]
+    },  # noqa: E501
     classifiers=[
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,9 @@ setup(
     url="https://srevinsaju.github.io/guiscrcpy",
     download_url="https://github.com/srevinsaju/guiscrcpy/archive/master.zip",
     include_package_data=True,
+    package_data={
+        "guiscrcpy": ["ui/icons/guiscrcpy_logo_SRj_icon.ico"]
+    },
     install_requires=requirements,
     scripts=["scripts/guiscrcpy"],
     entry_points={'console_scripts': ['guiscrcpy = guiscrcpy.cli:cli']},  # noqa: E501


### PR DESCRIPTION
This fix Windows Shortcut problem. To create shortcut run this code in python:
```python
from guiscrcpy.platform.windows_tools.tools import make_shortcut
make_shortcut()
```

Changes:
- Minimum Python version is Python 3.7
- `guiscrcpy_logo_SRj_icon.ico` is added to package_data
- Add `guiscrcpy-noconsole` gui scripts
- Use wrapped Popen function to run command