### PR TITLE
Fix guiscrcpy use Python generic icon in Windows taskbar

### DIFF
--- a/guiscrcpy/cli.py
+++ b/guiscrcpy/cli.py
@@ -133,6 +133,13 @@ def cli(
         # it will log the traceback to the terminal
         # but it would not be visible to users without CLI interface
         # enable High DPI scaling
+
+        if platform.system() == "Windows":
+            import ctypes
+
+            appid = "srevinsaju.guiscrcpy"
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)
+
         QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
         # use HIGH DPI icons
         QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)

--- a/guiscrcpy/cli.py
+++ b/guiscrcpy/cli.py
@@ -136,7 +136,7 @@ def cli(
 
         if platform.system() == "Windows":
             import ctypes
-
+            # https://stackoverflow.com/a/1552105/9986755
             appid = "srevinsaju.guiscrcpy"
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)
 


### PR DESCRIPTION
This wil fix guiscrcpy use Python generic icon in Windows taskbar. This also will fix guiscrcpy use same taskbar with other Python application in Windows.