### PR TITLE
ability to add five-digit port number

### DIFF
--- a/guiscrcpy/ui/network.ui
+++ b/guiscrcpy/ui/network.ui
@@ -77,7 +77,7 @@
           <number>1000</number>
          </property>
          <property name="maximum">
-          <number>9999</number>
+          <number>99999</number>
          </property>
          <property name="value">
           <number>5555</number>


### PR DESCRIPTION
In MIUI 12 (Android 11) there is a wireless debugging option, the length of the port number that generated by the system is five.
![image](https://user-images.githubusercontent.com/13608702/110233781-51059980-7f1e-11eb-84da-c1bff1f0d858.png)
