### PR TITLE
Fix typo in variable _api

### DIFF
--- a/guiscrcpy/lib/bridge/adb.py
+++ b/guiscrcpy/lib/bridge/adb.py
@@ -11,7 +11,7 @@ class AndroidDebugBridge(Bridge):
     name = "adb"
 
     def get_target_android_version(self, device_id=None):
-        _api = -1
+        api = -1
 
         # This function uses device API level to identify different android versions instead of
         # Android version as they can break in scenarios where version names are like 8.1.0


### PR DESCRIPTION
Fixed mis-spelt variable that could lead to crash if `_ecode` would not be `0`